### PR TITLE
feat: 유저별 루틴 조회 기능 및 테스트 추가

### DIFF
--- a/src/main/java/com/example/routinegrowth/mapper/RoutineMapper.java
+++ b/src/main/java/com/example/routinegrowth/mapper/RoutineMapper.java
@@ -1,0 +1,13 @@
+package com.example.routinegrowth.mapper;
+
+import com.example.routinegrowth.DTO.RoutineResponse;
+import com.example.routinegrowth.entity.Routine;
+
+public class RoutineMapper {
+  public static RoutineResponse toDto(Routine routine) {
+    return RoutineResponse.builder()
+        .content(routine.getContent())
+        .categoryName(routine.getCategory().getName())
+        .build();
+  }
+}

--- a/src/main/java/com/example/routinegrowth/repository/RoutineRepository.java
+++ b/src/main/java/com/example/routinegrowth/repository/RoutineRepository.java
@@ -1,8 +1,11 @@
 package com.example.routinegrowth.repository;
 
 import com.example.routinegrowth.entity.Routine;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RoutineRepository extends JpaRepository<Routine, Long> {}
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+  List<Routine> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/routinegrowth/service/RoutineService.java
+++ b/src/main/java/com/example/routinegrowth/service/RoutineService.java
@@ -65,7 +65,7 @@ public class RoutineService {
    * @param userId 루틴을 조회할 사용자 id
    * @return List<RoutineResponse>
    */
-  public List<RoutineResponse> searchRoutine(Long userId) {
+  public List<RoutineResponse> searchRoutines(Long userId) {
     // get all routines by user id
     List<Routine> routines = routineRepository.findByUserId(userId);
 

--- a/src/main/java/com/example/routinegrowth/service/RoutineService.java
+++ b/src/main/java/com/example/routinegrowth/service/RoutineService.java
@@ -5,9 +5,12 @@ import com.example.routinegrowth.DTO.RoutineResponse;
 import com.example.routinegrowth.entity.Routine;
 import com.example.routinegrowth.entity.RoutineCategory;
 import com.example.routinegrowth.entity.User;
+import com.example.routinegrowth.mapper.RoutineMapper;
 import com.example.routinegrowth.repository.RoutineCategoryRepository;
 import com.example.routinegrowth.repository.RoutineRepository;
 import com.example.routinegrowth.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -54,5 +57,19 @@ public class RoutineService {
         .content(routineRequest.getContent())
         .categoryName(routineSaved.getCategory().getName())
         .build();
+  }
+
+  /**
+   * Search routine by user id
+   *
+   * @param userId 루틴을 조회할 사용자 id
+   * @return List<RoutineResponse>
+   */
+  public List<RoutineResponse> searchRoutine(Long userId) {
+    // get all routines by user id
+    List<Routine> routines = routineRepository.findByUserId(userId);
+
+    // convert to List<RoutineReponse> and return
+    return routines.stream().map(RoutineMapper::toDto).collect(Collectors.toList());
   }
 }

--- a/src/test/java/com/example/routinegrowth/RoutineServiceTest.java
+++ b/src/test/java/com/example/routinegrowth/RoutineServiceTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.List;
+
 @Slf4j
 @SpringBootTest
 @DisplayName("Routine Service Test")
@@ -78,5 +80,57 @@ public class RoutineServiceTest extends BaseServiceTest {
 
     // expectation
     assertThat(exception.getMessage()).isEqualTo("Routine category not found");
+  }
+
+  // 루틴 조회 테스트 : 성공
+  @Test
+  @DisplayName("Successful Routine Retrieval Test")
+  public void retrieveRoutine_success() {
+    // make RoutineRequest for new routine
+    Long userId = userResponse.getId();
+    RoutineRequest routineRequest =
+      new RoutineRequest(routineCategoryResponseExercise.getId(), "Lunch Routine");
+
+    try {
+      // make routine for test
+      RoutineResponse routineResponse = routineService.createRoutine(userId, routineRequest);
+
+      // retrieve routine
+      assertThat(routineResponse).isNotNull();
+
+    } catch (Exception e) {
+      log.error(e.getMessage());
+    }
+
+    try {
+      // search routine
+      List<RoutineResponse> routineResponses = routineService.searchRoutine(userId);
+
+      // expectation
+      assertThat(routineResponses).isNotNull();
+      assertThat(routineResponses.size()).isEqualTo(1);
+      assertThat(routineResponses.get(0).getContent()).isEqualTo("Lunch Routine");
+    } catch (Exception e) {
+      log.error(e.getMessage());
+    }
+  }
+
+  // 루틴 조회 테스트 : 없는 경우
+  @Test
+  @DisplayName("No Routine Searched Test")
+  public void retrieveRoutine_noRoutine() {
+    // make RoutineRequest for new routine
+    Long userId = userResponse.getId();
+
+    try {
+      // search routine
+      List<RoutineResponse> routineResponses = routineService.searchRoutine(userId);
+
+      // expectation
+      assertThat(routineResponses).isNotNull();
+      assertThat(routineResponses.size()).isEqualTo(0);
+    } catch (Exception e) {
+      log.error(e.getMessage());
+    }
   }
 }

--- a/src/test/java/com/example/routinegrowth/RoutineServiceTest.java
+++ b/src/test/java/com/example/routinegrowth/RoutineServiceTest.java
@@ -8,6 +8,7 @@ import com.example.routinegrowth.DTO.RoutineResponse;
 import com.example.routinegrowth.common.BaseServiceTest;
 import com.example.routinegrowth.service.RoutineService;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -15,8 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.List;
 
 @Slf4j
 @SpringBootTest
@@ -82,55 +81,39 @@ public class RoutineServiceTest extends BaseServiceTest {
     assertThat(exception.getMessage()).isEqualTo("Routine category not found");
   }
 
-  // 루틴 조회 테스트 : 성공
+  /** 루틴 조회 테스트 : 성공 */
   @Test
-  @DisplayName("Successful Routine Retrieval Test")
-  public void retrieveRoutine_success() {
+  @DisplayName("Successful Routine Search Test")
+  public void retrieveRoutine_success() throws Exception {
     // make RoutineRequest for new routine
     Long userId = userResponse.getId();
     RoutineRequest routineRequest =
-      new RoutineRequest(routineCategoryResponseExercise.getId(), "Lunch Routine");
+        new RoutineRequest(routineCategoryResponseExercise.getId(), "Lunch Routine");
 
-    try {
-      // make routine for test
-      RoutineResponse routineResponse = routineService.createRoutine(userId, routineRequest);
+    // make routine for test
+    routineService.createRoutine(userId, routineRequest);
 
-      // retrieve routine
-      assertThat(routineResponse).isNotNull();
+    // search routine
+    List<RoutineResponse> routineResponses = routineService.searchRoutine(userId);
 
-    } catch (Exception e) {
-      log.error(e.getMessage());
-    }
-
-    try {
-      // search routine
-      List<RoutineResponse> routineResponses = routineService.searchRoutine(userId);
-
-      // expectation
-      assertThat(routineResponses).isNotNull();
-      assertThat(routineResponses.size()).isEqualTo(1);
-      assertThat(routineResponses.get(0).getContent()).isEqualTo("Lunch Routine");
-    } catch (Exception e) {
-      log.error(e.getMessage());
-    }
+    // expectation
+    assertThat(routineResponses).isNotNull();
+    assertThat(routineResponses.size()).isEqualTo(1);
+    assertThat(routineResponses.get(0).getContent()).isEqualTo("Lunch Routine");
   }
 
-  // 루틴 조회 테스트 : 없는 경우
+  /** 루틴 조회 테스트 : 없는 경우 */
   @Test
   @DisplayName("No Routine Searched Test")
   public void retrieveRoutine_noRoutine() {
     // make RoutineRequest for new routine
     Long userId = userResponse.getId();
 
-    try {
-      // search routine
-      List<RoutineResponse> routineResponses = routineService.searchRoutine(userId);
+    // search routine
+    List<RoutineResponse> routineResponses = routineService.searchRoutine(userId);
 
-      // expectation
-      assertThat(routineResponses).isNotNull();
-      assertThat(routineResponses.size()).isEqualTo(0);
-    } catch (Exception e) {
-      log.error(e.getMessage());
-    }
+    // expectation
+    assertThat(routineResponses).isNotNull();
+    assertThat(routineResponses.size()).isEqualTo(0);
   }
 }

--- a/src/test/java/com/example/routinegrowth/RoutineServiceTest.java
+++ b/src/test/java/com/example/routinegrowth/RoutineServiceTest.java
@@ -94,7 +94,7 @@ public class RoutineServiceTest extends BaseServiceTest {
     routineService.createRoutine(userId, routineRequest);
 
     // search routine
-    List<RoutineResponse> routineResponses = routineService.searchRoutine(userId);
+    List<RoutineResponse> routineResponses = routineService.searchRoutines(userId);
 
     // expectation
     assertThat(routineResponses).isNotNull();
@@ -110,7 +110,7 @@ public class RoutineServiceTest extends BaseServiceTest {
     Long userId = userResponse.getId();
 
     // search routine
-    List<RoutineResponse> routineResponses = routineService.searchRoutine(userId);
+    List<RoutineResponse> routineResponses = routineService.searchRoutines(userId);
 
     // expectation
     assertThat(routineResponses).isNotNull();


### PR DESCRIPTION
## 🔍 개요
- 유저 ID를 기반으로 등록된 루틴 목록을 조회하는 기능을 추가했습니다.

## ✅ 주요 변경 사항
- `RoutineService`에 `searchRoutine(Long userId)` 메서드 구현
- `RoutineRepository`에서 유저 ID 기반 루틴 조회 기능 활용
- 조회된 `Routine` 엔티티 리스트를 `RoutineResponse` DTO로 매핑
- 루틴 조회 관련 테스트 케이스 2건 작성:
  - 루틴 존재 시 정상 조회
  - 루틴이 존재하지 않을 경우 빈 리스트 반환

## 🧪 테스트
- `RoutineServiceTest`에 테스트 메서드 추가
- 전체 테스트 통과 확인 ✅